### PR TITLE
Check that sound manager instance is not null

### DIFF
--- a/src/main/java/com/falsepattern/ssmlegacy/mixin/mixins/client/vanilla/SoundManagerMixin.java
+++ b/src/main/java/com/falsepattern/ssmlegacy/mixin/mixins/client/vanilla/SoundManagerMixin.java
@@ -15,7 +15,7 @@ public abstract class SoundManagerMixin {
             require = 1,
             cancellable = true)
     private void handleCancel(ISound sound, CallbackInfo ci) {
-        if (SuperSoundMuffler.instance.shouldMuffle(sound)) {
+        if (SuperSoundMuffler.instance != null && SuperSoundMuffler.instance.shouldMuffle(sound)) {
             ci.cancel();
         }
     }


### PR DESCRIPTION
I have been receiving the following crash quite frequently under certain circumstances while loading my modpack, particularly if there is a missing mod and Forge skips directly to the missing mods screen:

```
[13:34:48] [Client thread/INFO] [STDOUT/]: [makamys.coretweaks.tweak.crashhandler.CrashHandler:createCrashReport:44]: ---- Minecraft Crash Report ----
// Sorry :(

Time: 5/5/22 1:34 PM
Description: Unexpected error

java.lang.NullPointerException: Unexpected error
        at net.minecraft.client.audio.SoundManager.handler$handleCancel$zee000(SoundManager.java:546)
        at net.minecraft.client.audio.SoundManager.func_148611_c(SoundManager.java)
        at net.minecraft.client.audio.SoundHandler.func_147682_a(SourceFile:154)
        at net.minecraft.client.audio.MusicTicker.func_73660_a(SourceFile:41)
        at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:2012)
        at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973)
        at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:3500)
        at net.minecraft.client.main.Main.main(SourceFile:148)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
        at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:210)
        at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:245)
        at org.multimc.EntryPoint.listen(EntryPoint.java:143)
        at org.multimc.EntryPoint.main(EntryPoint.java:34)
```

I presume that Forge doesn't bother initializing mod instance fields if loading fails. This prevents an infinite stream of crashes by simply not cancelling sounds if the mod isn't initialized for whatever reason.